### PR TITLE
chore(internal): prevent leaking deprecations upstream

### DIFF
--- a/test-app/config/deprecation-workflow.js
+++ b/test-app/config/deprecation-workflow.js
@@ -1,0 +1,10 @@
+'use strict';
+
+self.deprecationWorkflow = self.deprecationWorkflow || {};
+self.deprecationWorkflow.config = {
+  // eagerly throw on deprecations to prevent introducing
+  // warnings to upstream consumers
+  throwOnUnhandled: true,
+
+  workflow: [],
+};

--- a/test-app/ember-cli-build.js
+++ b/test-app/ember-cli-build.js
@@ -6,10 +6,6 @@ const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 // eslint-disable-next-line node/no-extraneous-require, node/no-missing-require
 const { configureTailwind } = require('@crowdstrike/ember-toucan-styles');
 
-// Intimate / Private information:
-// https://github.com/embroider-build/embroider/blob/main/packages/test-setup/src/index.ts#L85
-process.env.EMBROIDER_TEST_SETUP_OPTIONS = 'optimized';
-
 module.exports = function (defaults) {
   let buildParams = {
     ...configureTailwind(),
@@ -26,5 +22,11 @@ module.exports = function (defaults) {
 
   const { maybeEmbroider } = require('@embroider/test-setup');
 
-  return maybeEmbroider(app);
+  return maybeEmbroider(app, {
+    skipBabel: [
+      {
+        package: 'qunit',
+      },
+    ],
+  });
 };


### PR DESCRIPTION
For all our open-source ember projects, if we set `throwOnUnhandled` to `true`, we prevent ourselves from introducing upstream deprecations. This is possible due to the wide testing matrix that our open source addons implement -- when we do want to add support for another ember version, we can _incrementally_ fix any potential deprecation-violations on a per-package level and feel productive about completing smaller buckets of work before pulling in our upstream internal monorepo(s).