### PR TITLE
fix(ember-cli): compat with ember-cli's classic build

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ To configure an Ember App, modify:
 ```cjs
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
-const { configureTailwind } = require('@crowdstrike/ember-toucan-styles');
+const { configureTailwind } = require('@crowdstrike/ember-toucan-styles/ember-cli');
 
 const tailwindConfig = require('./tailwind.config');
 
@@ -195,7 +195,7 @@ output before `@tailwind base;`
 
 const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
-const { configureTailwind } = require('@crowdstrike/ember-toucan-styles');
+const { configureTailwind } = require('@crowdstrike/ember-toucan-styles/ember-cli');
 
 const tailwindConfig = require('./tailwind.config');
 
@@ -236,8 +236,8 @@ Follow these steps:
  - change `ember-cli-build.js`
 
     ```diff
-    -const { configureTailwind } = require('@crowdstrike/ember-toucan-styles');
-    +const { configureCSSModules } = require('@crowdstrike/ember-toucan-styles');
+    -const { configureTailwind } = require('@crowdstrike/ember-toucan-styles/ember-cli');
+    +const { configureCSSModules } = require('@crowdstrike/ember-toucan-styles/ember-cli');
     ```
 
     To use this in an addon, you'll want to apply these to the `options` object of the v1 addon's index.js.

--- a/ember-toucan-styles/package.json
+++ b/ember-toucan-styles/package.json
@@ -14,10 +14,8 @@
   "license": "MIT",
   "author": "CrowdStrike UX Team",
   "exports": {
-    ".": {
-      "import": "./dist/index.js",
-      "require": "./src/ember-cli/index.cjs"
-    },
+    ".": "./dist/index.js",
+    "./ember-cli": "./src/ember-cli/index.cjs",
     "./test-support": "./dist/test-support/index.js",
     "./*": "./dist/*"
   },
@@ -55,22 +53,14 @@
   "dependencies": {
     "@crowdstrike/tailwind-toucan-base": "^3.1.1",
     "@embroider/addon-shim": "^1.7.1",
-    "ember-browser-services": "^4.0.3"
+    "ember-browser-services": "^4.0.3",
+    "postcss-import": "^14.1.0",
+    "postcss": "^8.0.0"
   },
   "peerDependencies": {
     "@glimmer/tracking": "^1.1.2",
     "ember-source": "^3.24.0 || >= 4.0.0",
-    "postcss": "^8.0.0",
-    "postcss-import": "^14.1.0",
     "tailwindcss": "^2.2.15 || ^3.0.0"
-  },
-  "peerDependenciesMeta": {
-    "postcss-import": {
-      "optional": true
-    },
-    "postcss": {
-      "optional": true
-    }
   },
   "devDependencies": {
     "@babel/core": "7.18.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,7 +51,8 @@ importers:
       eslint-plugin-node: 11.1.0
       eslint-plugin-prettier: 4.0.0
       eslint-plugin-simple-import-sort: 7.0.0
-      postcss: ^8.2.14
+      postcss: ^8.0.0
+      postcss-import: ^14.1.0
       prettier: ^2.5.1
       rollup: 2.75.6
       rollup-plugin-ts: 3.0.2
@@ -62,6 +63,8 @@ importers:
       '@crowdstrike/tailwind-toucan-base': 3.1.1_ugi4xkrfysqkt4c4y6hkyfj344
       '@embroider/addon-shim': 1.7.1
       ember-browser-services: 4.0.3
+      postcss: 8.4.14
+      postcss-import: 14.1.0_postcss@8.4.14
     devDependencies:
       '@babel/core': 7.18.2
       '@babel/plugin-proposal-class-properties': 7.17.12_@babel+core@7.18.2
@@ -93,7 +96,6 @@ importers:
       eslint-plugin-node: 11.1.0_eslint@7.32.0
       eslint-plugin-prettier: 4.0.0_evcial7aw3q6fcauxv2c7fxuoe
       eslint-plugin-simple-import-sort: 7.0.0_eslint@7.32.0
-      postcss: 8.4.14
       prettier: 2.6.2
       rollup: 2.75.6
       rollup-plugin-ts: 3.0.2_zhhruumeih4cvi76ufpovrqpve
@@ -12740,7 +12742,6 @@ packages:
   /pify/2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /pify/3.0.0:
     resolution: {integrity: sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==}
@@ -12825,7 +12826,6 @@ packages:
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.0
-    dev: true
 
   /postcss-js/3.0.3:
     resolution: {integrity: sha512-gWnoWQXKFw65Hk/mi2+WTQTHdPD5UJdDXZmX073EY/B3BWnYjO4F4t0VneTCnCGQ5E5GsCdMkzPaTXwl3r5dJw==}
@@ -13207,7 +13207,6 @@ packages:
     resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
     dependencies:
       pify: 2.3.0
-    dev: true
 
   /read-pkg-up/7.0.1:
     resolution: {integrity: sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==}

--- a/test-app/ember-cli-build.js
+++ b/test-app/ember-cli-build.js
@@ -2,9 +2,17 @@
 
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
-// eslint doesn't know that we can require ourselves :D
-// eslint-disable-next-line node/no-extraneous-require, node/no-missing-require
-const { configureTailwind } = require('@crowdstrike/ember-toucan-styles');
+const {
+  configureCSSModules,
+  configureTailwind,
+  // eslint doesn't know that we can require ourselves :D
+  // eslint-disable-next-line node/no-extraneous-require, node/no-missing-require
+} = require('@crowdstrike/ember-toucan-styles/ember-cli');
+
+/**
+ * Testing that these utilities are both resolveable from an ember app
+ */
+console.debug({ configureTailwind, configureCSSModules });
 
 module.exports = function (defaults) {
   let buildParams = {


### PR DESCRIPTION
in legacy ember-cli projects, `require` is resolved instead of `import` for the `exports` field of package.json. Because we were trying to re-use the same import path, but have different behaviors in node and browser, we ran in to issues. 

This PR moves the ember-cli utilities to an `/ember-cli` export that consumers can use as to not confuse with the ESM files.