### PR TITLE
Automatically register the scrollbar CSS.

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,9 @@
+{
+  "mode": "pre",
+  "tag": "beta",
+  "initialVersions": {
+    "@crowdstrike/ember-toucan-styles": "1.0.5",
+    "test-app": "0.0.0"
+  },
+  "changesets": []
+}

--- a/.changeset/sixty-flowers-reply.md
+++ b/.changeset/sixty-flowers-reply.md
@@ -1,0 +1,20 @@
+---
+"@crowdstrike/ember-toucan-styles": major
+---
+
+This is a breaking change is it requires that consumers have a way to properly resolve side-affecting CSS imports
+(this is commonplace in many webpack and vite apps though).
+
+(ember-auto-import and embroider)-based ember apps support this out of the box.
+
+Here is a tutorial on setting up Tailwind 3 + JIT, CSS imports, and (optionally) CSS-Modules, for those interested https://discuss.emberjs.com/t/ember-modern-css/19614
+
+To migrate to this version of `@crowdstrike/ember-toucan-styles`, remove any previously referenced
+
+```css
+@import "@crowdstrike/ember-toucan-styles/scollbar.css";
+```
+
+in your CSS.
+
+This is now imported for you via the included service.

--- a/README.md
+++ b/README.md
@@ -265,14 +265,6 @@ Example:
 
 </details>
 
-### Scrollbar Styles
-
-To get toucan-themed scrollbars in browsers that support scrollbar customization
-
-```css
-@import '@crowdstrike/ember-toucan-styles/scollbar.css'
-```
-
 ### Using a Custom Theme Manager
 
 #### Setup

--- a/ember-toucan-styles/src/index.ts
+++ b/ember-toucan-styles/src/index.ts
@@ -1,3 +1,5 @@
 export { default as ThemeManager } from './services/theme-manager';
 export * from './utils/colors';
 export * from './utils/themes';
+
+import './scrollbar.css';

--- a/ember-toucan-styles/src/index.ts
+++ b/ember-toucan-styles/src/index.ts
@@ -1,5 +1,3 @@
 export { default as ThemeManager } from './services/theme-manager';
 export * from './utils/colors';
 export * from './utils/themes';
-
-import './scrollbar.css';

--- a/ember-toucan-styles/src/services/theme-manager.ts
+++ b/ember-toucan-styles/src/services/theme-manager.ts
@@ -1,3 +1,5 @@
+import '../scrollbar.css';
+
 import { tracked } from '@glimmer/tracking';
 import { assert } from '@ember/debug';
 import { registerDestructor } from '@ember/destroyable';


### PR DESCRIPTION
This is a breaking change is it requires that consumers have a way to properly resolve side-affecting CSS imports
(this is commonplace in many webpack and vite apps though).

(ember-auto-import and embroider)-based ember apps support this out of the box.

Here is a tutorial on setting up Tailwind 3 + JIT, CSS imports, and (optionally) CSS-Modules, for those interested https://discuss.emberjs.com/t/ember-modern-css/19614