### PR TITLE
Add helper functions to access the new Charts Color Palette

### DIFF
--- a/.changeset/olive-keys-sing.md
+++ b/.changeset/olive-keys-sing.md
@@ -1,0 +1,5 @@
+---
+"@crowdstrike/ember-toucan-styles": minor
+---
+
+Add helper functions for new Charts color palette

--- a/ember-toucan-styles/package.json
+++ b/ember-toucan-styles/package.json
@@ -52,7 +52,7 @@
     "prepublishOnly": "pnpm build"
   },
   "dependencies": {
-    "@crowdstrike/tailwind-toucan-base": "^4.3.0",
+    "@crowdstrike/tailwind-toucan-base": "^4.4.0",
     "@embroider/addon-shim": "^1.7.1",
     "ember-browser-services": "^4.0.3"
   },

--- a/ember-toucan-styles/src/utils/colors.ts
+++ b/ember-toucan-styles/src/utils/colors.ts
@@ -80,21 +80,28 @@ export function getColorScale(numItems: number) {
   return Array.from({ length: numItems }, (_, i) => GRAPH_COLORS[(i + 3) % numColors]);
 }
 
+function getSwatchesForPalette(palette:  'graph' | 'chart' | 'chart-neutral') {
+  let currentTheme = getCurrentTheme();
+
+  const VALID_PALETTE_COLOR = new RegExp(`${palette}-(\\d+)`);
+
+  const swatches = Object.values(themeData.themes[currentTheme].colors)
+    .filter(({ name }) => VALID_PALETTE_COLOR.test(name))
+    .map(({ name }) => ({
+      // For each palette, there is a test that asserts `swatchName` is a string for all possible values
+      swatchName: name as string,
+      swatchClass: `text-${name}`,
+      i: parseInt(name.substring(palette.length + 1)),
+    }))
+    .sort((a, b) => a.i - b.i);
+
+  return swatches
+}
+
 export function getGraphColors(count = 11) {
   assert(`requested ${count} graph colors, more than the allowed maximum of 11`, count <= 11);
 
-  let currentTheme = getCurrentTheme();
-
-  const VALID_GRAPH_COLOR = /graph-(\d+)/;
-
-  const swatches = Object.values(themeData.themes[currentTheme].colors)
-    .filter(({ name }) => VALID_GRAPH_COLOR.test(name))
-    .map(({ name }) => ({
-      swatchName: name,
-      swatchClass: `text-${name}`,
-      i: parseInt(name.substring(6)),
-    }))
-    .sort((a, b) => a.i - b.i);
+  const swatches = getSwatchesForPalette('graph')
 
   const _ = null;
   const [a, b, c, d, e, f, g, h, i, j, k] = swatches;
@@ -120,6 +127,30 @@ export function getGraphColors(count = 11) {
   const swatch = sorted[index];
 
   return swatch.filter((color) => color !== null);
+}
+
+export function getChartColors(count = 10, { includeNeutrals = false } = {}) {
+  const max = includeNeutrals ? 12 : 10;
+
+  assert(`requested ${count} chart colors, more than the allowed maximum of ${max}`, count <= max);
+
+  const swatches = getSwatchesForPalette('chart')
+
+  if (includeNeutrals) {
+    const neutralSwatches = getSwatchesForPalette('chart-neutral')
+
+    swatches.push(...neutralSwatches)
+  }
+
+  return swatches.slice(0, count)
+}
+
+export function getChartNeutralColors(count = 2) {
+  assert(`requested ${count} chart colors, more than the allowed maximum of 2`, count <= 2);
+
+  const swatches = getSwatchesForPalette('chart-neutral')
+
+  return swatches.slice(0, count)
 }
 
 export function getColor(swatchName: string) {

--- a/ember-toucan-styles/src/utils/colors.ts
+++ b/ember-toucan-styles/src/utils/colors.ts
@@ -80,7 +80,7 @@ export function getColorScale(numItems: number) {
   return Array.from({ length: numItems }, (_, i) => GRAPH_COLORS[(i + 3) % numColors]);
 }
 
-function getSwatchesForPalette(palette:  'graph' | 'chart' | 'chart-neutral') {
+function getSwatchesForPalette(palette: 'graph' | 'chart' | 'chart-neutral') {
   let currentTheme = getCurrentTheme();
 
   const VALID_PALETTE_COLOR = new RegExp(`${palette}-(\\d+)`);
@@ -95,13 +95,13 @@ function getSwatchesForPalette(palette:  'graph' | 'chart' | 'chart-neutral') {
     }))
     .sort((a, b) => a.i - b.i);
 
-  return swatches
+  return swatches;
 }
 
 export function getGraphColors(count = 11) {
   assert(`requested ${count} graph colors, more than the allowed maximum of 11`, count <= 11);
 
-  const swatches = getSwatchesForPalette('graph')
+  const swatches = getSwatchesForPalette('graph');
 
   const _ = null;
   const [a, b, c, d, e, f, g, h, i, j, k] = swatches;
@@ -134,23 +134,23 @@ export function getChartColors(count = 10, { includeNeutrals = false } = {}) {
 
   assert(`requested ${count} chart colors, more than the allowed maximum of ${max}`, count <= max);
 
-  const swatches = getSwatchesForPalette('chart')
+  const swatches = getSwatchesForPalette('chart');
 
   if (includeNeutrals) {
-    const neutralSwatches = getSwatchesForPalette('chart-neutral')
+    const neutralSwatches = getSwatchesForPalette('chart-neutral');
 
-    swatches.push(...neutralSwatches)
+    swatches.push(...neutralSwatches);
   }
 
-  return swatches.slice(0, count)
+  return swatches.slice(0, count);
 }
 
 export function getChartNeutralColors(count = 2) {
   assert(`requested ${count} chart colors, more than the allowed maximum of 2`, count <= 2);
 
-  const swatches = getSwatchesForPalette('chart-neutral')
+  const swatches = getSwatchesForPalette('chart-neutral');
 
-  return swatches.slice(0, count)
+  return swatches.slice(0, count);
 }
 
 export function getColor(swatchName: string) {

--- a/ember-toucan-styles/src/utils/colors.ts
+++ b/ember-toucan-styles/src/utils/colors.ts
@@ -129,7 +129,8 @@ export function getGraphColors(count = 11) {
   return swatch.filter((color) => color !== null);
 }
 
-export function getChartColors(count = 10, { includeNeutrals = false } = {}) {
+// By default includes '1' neutral color at the end of the palette, similar to graph
+export function getChartColors(count = 11, { includeNeutrals = true } = {}) {
   const max = includeNeutrals ? 12 : 10;
 
   assert(`requested ${count} chart colors, more than the allowed maximum of ${max}`, count <= max);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,7 +26,7 @@ importers:
       '@babel/preset-env': ^7.18.2
       '@babel/preset-typescript': 7.17.12
       '@babel/runtime': ^7.18.3
-      '@crowdstrike/tailwind-toucan-base': ^4.3.0
+      '@crowdstrike/tailwind-toucan-base': ^4.4.0
       '@embroider/addon-dev': ^3.0.0
       '@embroider/addon-shim': ^1.7.1
       '@glimmer/tracking': ^1.1.2
@@ -55,7 +55,7 @@ importers:
       tslib: ^2.4.0
       typescript: 4.7.3
     dependencies:
-      '@crowdstrike/tailwind-toucan-base': 4.3.0_ylhgd75g3bp34wx2skvudh5vca
+      '@crowdstrike/tailwind-toucan-base': 4.4.0_ylhgd75g3bp34wx2skvudh5vca
       '@embroider/addon-shim': 1.8.6
       ember-browser-services: 4.0.4
     devDependencies:
@@ -99,7 +99,7 @@ importers:
       '@babel/core': 7.20.12
       '@babel/eslint-parser': ^7.19.1
       '@crowdstrike/ember-toucan-styles': workspace:../ember-toucan-styles
-      '@crowdstrike/tailwind-toucan-base': ^4.3.0
+      '@crowdstrike/tailwind-toucan-base': ^4.4.0
       '@ember/optional-features': ^2.0.0
       '@ember/string': ^3.0.1
       '@ember/test-helpers': ^2.6.0
@@ -167,7 +167,7 @@ importers:
       webpack: ^5.65.0
     dependencies:
       '@crowdstrike/ember-toucan-styles': link:../ember-toucan-styles
-      '@crowdstrike/tailwind-toucan-base': 4.3.0_ylhgd75g3bp34wx2skvudh5vca
+      '@crowdstrike/tailwind-toucan-base': 4.4.0_ylhgd75g3bp34wx2skvudh5vca
       ember-browser-services: 4.0.4
     devDependencies:
       '@babel/core': 7.20.12
@@ -1780,8 +1780,8 @@ packages:
     dev: true
     optional: true
 
-  /@crowdstrike/tailwind-toucan-base/4.3.0_ylhgd75g3bp34wx2skvudh5vca:
-    resolution: {integrity: sha512-jDWipoqCX6w35zV8W+czf1nXHLAtW5ZDlRfJnHgARlv0GHp1pOAU0n2cE3RMWTzLEThfpNwGh7hy377X5W5qdw==}
+  /@crowdstrike/tailwind-toucan-base/4.4.0_ylhgd75g3bp34wx2skvudh5vca:
+    resolution: {integrity: sha512-43B4MO3tpIxpLoQiCm8WhQmx14NVD5PDCUa2m0mW9y1+Ij8WoKxz6MjvT7V4+Vh50PL/lJisUbVFRHq7XE27Tg==}
     engines: {node: '>=14.15.0'}
     dependencies:
       tailwindcss: 2.2.19_ylhgd75g3bp34wx2skvudh5vca

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -27,7 +27,7 @@
     "lint:prettier": "prettier -c ."
   },
   "dependencies": {
-    "@crowdstrike/tailwind-toucan-base": "^4.3.0",
+    "@crowdstrike/tailwind-toucan-base": "^4.4.0",
     "@crowdstrike/ember-toucan-styles": "workspace:../ember-toucan-styles",
     "ember-browser-services": "^4.0.3"
   },

--- a/test-app/tests/unit/utils/colors-test.js
+++ b/test-app/tests/unit/utils/colors-test.js
@@ -1,9 +1,64 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-import { getColor, getGraphColors } from '@crowdstrike/ember-toucan-styles';
+import { getChartColors, getChartNeutralColors, getColor, getGraphColors } from '@crowdstrike/ember-toucan-styles';
 
 import { setupThemeSupport } from '@crowdstrike/ember-toucan-styles/test-support';
+
+const graphColors = [
+  'graph-1',
+  'graph-2',
+  'graph-3',
+  'graph-4',
+  'graph-5',
+  'graph-6',
+  'graph-7',
+  'graph-8',
+  'graph-9',
+  'graph-10',
+  'graph-11',
+]
+
+const chartColors = [
+  'chart-1',
+  'chart-2',
+  'chart-3',
+  'chart-4',
+  'chart-5',
+  'chart-6',
+  'chart-7',
+  'chart-8',
+  'chart-9',
+  'chart-10',
+]
+
+const chartNeutralColors = [
+  'chart-neutral-1',
+  'chart-neutral-2',
+]
+
+const paletteProperties = {
+  graph: {
+    max: 11,
+    colors: graphColors,
+    getColors: getGraphColors,
+  },
+  chart: {
+    max: 10,
+    colors: chartColors,
+    getColors: getChartColors,
+  },
+  'chart-neutral': {
+    max: 2,
+    colors: chartNeutralColors,
+    getColors: getChartNeutralColors,
+  },
+  'charts-with-neutral': {
+    max: 12,
+    colors: [...chartColors, ...chartNeutralColors],
+    getColors: (count = 12) => getChartColors(count, { includeNeutrals: true }),
+  }
+}
 
 module('Unit | Utils | Colors ', function (hooks) {
   setupTest(hooks);
@@ -23,52 +78,44 @@ module('Unit | Utils | Colors ', function (hooks) {
     );
   });
 
-  test('it returns the color wheel palette color values correctly', function (assert) {
-    let graphColors = getGraphColors();
+  Object.keys(paletteProperties).map(palette=> {
+    const { colors, getColors, max } = paletteProperties[palette]
 
-    assert.expect(graphColors.length * 3 + 1);
+    test(`it returns the ${palette} color wheel palette color values correctly`, function (assert) {
+      let paletteColors = getColors();
 
-    graphColors.forEach((color) => {
-      assert.strictEqual(typeof color, 'object', 'color is an object');
-      assert.strictEqual(typeof color.swatchName, 'string', 'color object has a swatch name');
-      assert.strictEqual(typeof color.swatchClass, 'string', 'color object has a swatch class');
+      assert.expect(paletteColors.length * 3 + 1);
+
+      paletteColors.forEach((color) => {
+        assert.strictEqual(typeof color, 'object', 'color is an object');
+        assert.strictEqual(typeof color.swatchName, 'string', 'color object has a swatch name');
+        assert.strictEqual(typeof color.swatchClass, 'string', 'color object has a swatch class');
+      });
+      assert.deepEqual(
+        paletteColors.map((item) => item.swatchName),
+        colors,
+        `Full color wheel palette colors returned in the correct order`
+      );
     });
-    assert.deepEqual(
-      graphColors.map((item) => item.swatchName),
-      [
-        'graph-1',
-        'graph-2',
-        'graph-3',
-        'graph-4',
-        'graph-5',
-        'graph-6',
-        'graph-7',
-        'graph-8',
-        'graph-9',
-        'graph-10',
-        'graph-11',
-      ],
-      `Full color wheel palette colors returned in the correct order`
-    );
-  });
 
-  test('provides only as many categorical colors as necessary', function (assert) {
-    assert.expect(11);
+    test(`provides only as many categorical ${palette} colors as necessary`, function (assert) {
+      assert.expect(max);
 
-    for (let i = 1; i <= 11; i++) {
-      assert.strictEqual(getGraphColors(i).length, i);
-    }
-  });
+      for (let i = 1; i <= max; i++) {
+        assert.strictEqual(getColors(i).length, i);
+      }
+    });
 
-  test('provides a maximum of 11 colors', function (assert) {
-    assert.throws(() => getGraphColors(12));
-  });
+    test(`provides a maximum of ${max} ${palette} colors`, function (assert) {
+      assert.throws(() => getColors(max + 1));
+    });
 
-  test('changes every color in the palette', function (assert) {
-    assert.expect(11);
+    test(`changes every color in the ${palette} palette`, function (assert) {
+      assert.expect(max);
 
-    for (let i = 1; i <= 11; i++) {
-      assert.strictEqual(getGraphColors(i).length, new Set(getGraphColors(i)).size);
-    }
-  });
+      for (let i = 1; i <= max; i++) {
+        assert.strictEqual(getColors(i).length, new Set(getColors(i)).size);
+      }
+    });
+  })
 });

--- a/test-app/tests/unit/utils/colors-test.js
+++ b/test-app/tests/unit/utils/colors-test.js
@@ -1,7 +1,12 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-import { getChartColors, getChartNeutralColors, getColor, getGraphColors } from '@crowdstrike/ember-toucan-styles';
+import {
+  getChartColors,
+  getChartNeutralColors,
+  getColor,
+  getGraphColors,
+} from '@crowdstrike/ember-toucan-styles';
 
 import { setupThemeSupport } from '@crowdstrike/ember-toucan-styles/test-support';
 
@@ -17,7 +22,7 @@ const graphColors = [
   'graph-9',
   'graph-10',
   'graph-11',
-]
+];
 
 const chartColors = [
   'chart-1',
@@ -30,12 +35,9 @@ const chartColors = [
   'chart-8',
   'chart-9',
   'chart-10',
-]
+];
 
-const chartNeutralColors = [
-  'chart-neutral-1',
-  'chart-neutral-2',
-]
+const chartNeutralColors = ['chart-neutral-1', 'chart-neutral-2'];
 
 const paletteProperties = {
   graph: {
@@ -57,8 +59,8 @@ const paletteProperties = {
     max: 12,
     colors: [...chartColors, ...chartNeutralColors],
     getColors: (count = 12) => getChartColors(count, { includeNeutrals: true }),
-  }
-}
+  },
+};
 
 module('Unit | Utils | Colors ', function (hooks) {
   setupTest(hooks);
@@ -78,8 +80,8 @@ module('Unit | Utils | Colors ', function (hooks) {
     );
   });
 
-  Object.keys(paletteProperties).map(palette=> {
-    const { colors, getColors, max } = paletteProperties[palette]
+  Object.keys(paletteProperties).map((palette) => {
+    const { colors, getColors, max } = paletteProperties[palette];
 
     test(`it returns the ${palette} color wheel palette color values correctly`, function (assert) {
       let paletteColors = getColors();
@@ -117,5 +119,5 @@ module('Unit | Utils | Colors ', function (hooks) {
         assert.strictEqual(getColors(i).length, new Set(getColors(i)).size);
       }
     });
-  })
+  });
 });

--- a/test-app/tests/unit/utils/colors-test.js
+++ b/test-app/tests/unit/utils/colors-test.js
@@ -46,8 +46,9 @@ const paletteProperties = {
     getColors: getGraphColors,
   },
   chart: {
-    max: 10,
-    colors: chartColors,
+    max: 12,
+    defaultCount: 11,
+    colors: [...chartColors, ...chartNeutralColors],
     getColors: getChartColors,
   },
   'chart-neutral': {
@@ -55,10 +56,10 @@ const paletteProperties = {
     colors: chartNeutralColors,
     getColors: getChartNeutralColors,
   },
-  'charts-with-neutral': {
-    max: 12,
-    colors: [...chartColors, ...chartNeutralColors],
-    getColors: (count = 12) => getChartColors(count, { includeNeutrals: true }),
+  'charts-without-neutral': {
+    max: 10,
+    colors: chartColors,
+    getColors: (count = 10) => getChartColors(count, { includeNeutrals: false }),
   },
 };
 
@@ -81,7 +82,7 @@ module('Unit | Utils | Colors ', function (hooks) {
   });
 
   Object.keys(paletteProperties).map((palette) => {
-    const { colors, getColors, max } = paletteProperties[palette];
+    const { colors, getColors, max, defaultCount } = paletteProperties[palette];
 
     test(`it returns the ${palette} color wheel palette color values correctly`, function (assert) {
       let paletteColors = getColors();
@@ -95,7 +96,7 @@ module('Unit | Utils | Colors ', function (hooks) {
       });
       assert.deepEqual(
         paletteColors.map((item) => item.swatchName),
-        colors,
+        colors.slice(0, defaultCount ?? max),
         `Full color wheel palette colors returned in the correct order`
       );
     });


### PR DESCRIPTION
Follow up from this PR:
https://github.com/CrowdStrike/tailwind-toucan-base/pull/369

These colors will be specific to charts, not other types of data visualizations.

Notable Changes:
- Updated Tailwind-toucan-base package version.
- Two new methods: `getChartColors` and `getChartNeutralColors` to allow you to get the normal chart or neutral colors separately. `getChartColors` also has an optional argument if you want to exclude the neutral colors explicitly. By default it includes 1 neutral color the same as the `getGraphColors` method.
- The return type of `swatchName` in these colors was changed to a `string` instead of `any`. One of the existing tests validated this already, so I'm pretty sure this is just updating the type to be more accurate.
- The test coverage is the same as the existing graphs palette - I just made the existing tests a bit more generic so they can be looped through for each of the different palettes.