### PR TITLE
Update tailwind toucan base package version

### DIFF
--- a/.changeset/big-olives-taste.md
+++ b/.changeset/big-olives-taste.md
@@ -1,0 +1,5 @@
+---
+"@crowdstrike/ember-toucan-styles": major
+---
+
+Upgrade tailwind-toucan-base to latest major version. Breaking changes are only a concern if using the `surface-dash-widget` color with this package's utilities.

--- a/ember-toucan-styles/package.json
+++ b/ember-toucan-styles/package.json
@@ -52,7 +52,7 @@
     "prepublishOnly": "pnpm build"
   },
   "dependencies": {
-    "@crowdstrike/tailwind-toucan-base": "^4.4.0",
+    "@crowdstrike/tailwind-toucan-base": "^5.0.0",
     "@embroider/addon-shim": "^1.7.1",
     "ember-browser-services": "^4.0.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,7 +26,7 @@ importers:
       '@babel/preset-env': ^7.18.2
       '@babel/preset-typescript': 7.17.12
       '@babel/runtime': ^7.18.3
-      '@crowdstrike/tailwind-toucan-base': ^4.4.0
+      '@crowdstrike/tailwind-toucan-base': ^5.0.0
       '@embroider/addon-dev': ^3.0.0
       '@embroider/addon-shim': ^1.7.1
       '@glimmer/tracking': ^1.1.2
@@ -55,7 +55,7 @@ importers:
       tslib: ^2.4.0
       typescript: 4.7.3
     dependencies:
-      '@crowdstrike/tailwind-toucan-base': 4.4.0_ylhgd75g3bp34wx2skvudh5vca
+      '@crowdstrike/tailwind-toucan-base': 5.0.0_ylhgd75g3bp34wx2skvudh5vca
       '@embroider/addon-shim': 1.8.6
       ember-browser-services: 4.0.4
     devDependencies:
@@ -99,7 +99,7 @@ importers:
       '@babel/core': 7.20.12
       '@babel/eslint-parser': ^7.19.1
       '@crowdstrike/ember-toucan-styles': workspace:../ember-toucan-styles
-      '@crowdstrike/tailwind-toucan-base': ^4.4.0
+      '@crowdstrike/tailwind-toucan-base': ^5.0.0
       '@ember/optional-features': ^2.0.0
       '@ember/string': ^3.0.1
       '@ember/test-helpers': ^2.6.0
@@ -167,7 +167,7 @@ importers:
       webpack: ^5.65.0
     dependencies:
       '@crowdstrike/ember-toucan-styles': link:../ember-toucan-styles
-      '@crowdstrike/tailwind-toucan-base': 4.4.0_ylhgd75g3bp34wx2skvudh5vca
+      '@crowdstrike/tailwind-toucan-base': 5.0.0_ylhgd75g3bp34wx2skvudh5vca
       ember-browser-services: 4.0.4
     devDependencies:
       '@babel/core': 7.20.12
@@ -1780,8 +1780,8 @@ packages:
     dev: true
     optional: true
 
-  /@crowdstrike/tailwind-toucan-base/4.4.0_ylhgd75g3bp34wx2skvudh5vca:
-    resolution: {integrity: sha512-43B4MO3tpIxpLoQiCm8WhQmx14NVD5PDCUa2m0mW9y1+Ij8WoKxz6MjvT7V4+Vh50PL/lJisUbVFRHq7XE27Tg==}
+  /@crowdstrike/tailwind-toucan-base/5.0.0_ylhgd75g3bp34wx2skvudh5vca:
+    resolution: {integrity: sha512-9a6CFHN62sN1JhU4tU/C6px9W0eVqYhn1UsK0jjm6KxEnMoYwYPppLFDkiTxERPoUsJeEluWH4vbZ96P5UTIOg==}
     engines: {node: '>=14.15.0'}
     dependencies:
       tailwindcss: 2.2.19_ylhgd75g3bp34wx2skvudh5vca

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -27,7 +27,7 @@
     "lint:prettier": "prettier -c ."
   },
   "dependencies": {
-    "@crowdstrike/tailwind-toucan-base": "^4.4.0",
+    "@crowdstrike/tailwind-toucan-base": "^5.0.0",
     "@crowdstrike/ember-toucan-styles": "workspace:../ember-toucan-styles",
     "ember-browser-services": "^4.0.3"
   },


### PR DESCRIPTION
This is a follow-up from the Release of tailwind-toucan-base here:
https://github.com/CrowdStrike/tailwind-toucan-base/pull/400

Since that is a major version bump, this package also needs to be upgraded so they can be used alongside each other with the same version.

I marked this as `major` since the [getColor](https://github.com/CrowdStrike/ember-toucan-styles/blob/main/ember-toucan-styles/src/utils/colors.ts#L157) utility could have been used to retrieve the deleted `surface-dash-widget` color, but I think it's unlikely there are any breaking changes for consumers of this package in practice.