### PR TITLE
Support ember-browser-services v5

### DIFF
--- a/.changeset/silent-buckets-complain.md
+++ b/.changeset/silent-buckets-complain.md
@@ -1,0 +1,7 @@
+---
+"@crowdstrike/ember-toucan-styles": patch
+---
+
+Support ember-browser-services v5
+
+Widen the version range of the dependency on ember-browser-services to support both v4 and v5.

--- a/.github/actions/pnpm/action.yml
+++ b/.github/actions/pnpm/action.yml
@@ -3,12 +3,10 @@ description: Setup node and install dependencies using pnpm
 runs:
   using: "composite"
   steps:
-    - uses: pnpm/action-setup@v2.2.4
-      with:
-        version: 7
+    - uses: pnpm/action-setup@v4
     - uses: actions/setup-node@v3
       with:
-        cache: 'pnpm'
-    - name: 'Install dependencies'
-      shell: 'bash'
+        cache: "pnpm"
+    - name: "Install dependencies"
+      shell: "bash"
       run: pnpm install

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+strict-peer-dependencies=false

--- a/ember-toucan-styles/package.json
+++ b/ember-toucan-styles/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "@crowdstrike/tailwind-toucan-base": "^5.0.0",
     "@embroider/addon-shim": "^1.7.1",
-    "ember-browser-services": "^4.0.3"
+    "ember-browser-services": "^4.0.3 || ^5.0.0"
   },
   "peerDependencies": {
     "@glimmer/tracking": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@changesets/cli": "^2.26.0"
   },
   "volta": {
-    "node": "16.15.1",
+    "node": "18.20.4",
     "pnpm": "7.3.0"
   },
   "packageManager": "pnpm@7.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,7 +40,7 @@ importers:
       '@typescript-eslint/parser': ^5.51.0
       autoprefixer: ^10.0.2
       concurrently: 7.2.1
-      ember-browser-services: ^4.0.3
+      ember-browser-services: ^4.0.3 || ^5.0.0
       eslint: ^8.0.0
       eslint-plugin-decorator-position: ^5.0.0
       eslint-plugin-ember: 11.4.5
@@ -137,7 +137,7 @@ importers:
       broccoli-asset-rev: ^3.0.0
       concurrently: 7.2.1
       ember-auto-import: ^2.6.0
-      ember-browser-services: ^4.0.3
+      ember-browser-services: ^5.0.0
       ember-cli: ~4.1.1
       ember-cli-app-version: ^5.0.0
       ember-cli-babel: ^7.26.11
@@ -168,7 +168,7 @@ importers:
     dependencies:
       '@crowdstrike/ember-toucan-styles': link:../ember-toucan-styles
       '@crowdstrike/tailwind-toucan-base': 5.0.0_ylhgd75g3bp34wx2skvudh5vca
-      ember-browser-services: 4.0.4
+      ember-browser-services: 5.0.0
     devDependencies:
       '@babel/core': 7.20.12
       '@babel/eslint-parser': 7.22.15_v36i6bcmv5ciopwjdkqmyv6srm
@@ -1899,6 +1899,18 @@ packages:
       - supports-color
     dev: false
 
+  /@embroider/addon-shim/1.8.9:
+    resolution: {integrity: sha512-qyN64T1jMHZ99ihlk7VFHCWHYZHLE1DOdHi0J7lmn5waV1DoW7gD8JLi1i7FregzXtKhbDc7shyEmTmWPTs8MQ==}
+    engines: {node: 12.* || 14.* || >= 16}
+    dependencies:
+      '@embroider/shared-internals': 2.6.3
+      broccoli-funnel: 3.0.8
+      common-ancestor-path: 1.0.1
+      semver: 7.5.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@embroider/babel-loader-8/2.0.0_qt56qx6lyvsvzk63awaah47d7m:
     resolution: {integrity: sha512-a1bLodfox8JEgNHuhiIBIcXJ4b8NNnKWYkMIpJx216pn80Jf1jcFosQpxnqC8hYHrnG0XRKzQ9zJYgJXoa1wfg==}
     engines: {node: 12.* || 14.* || >= 16}
@@ -2088,6 +2100,27 @@ packages:
       - supports-color
     dev: true
 
+  /@embroider/macros/1.16.6:
+    resolution: {integrity: sha512-aSdRetg0vY3c70G/3K85fOSlGtDzSV4ozwF9qD8ToQB+4RLZusxwItnctWEa+MKkhAYB6rbFiQ+bhFwEnaEazg==}
+    engines: {node: 12.* || 14.* || >= 16}
+    peerDependencies:
+      '@glint/template': ^1.0.0
+    peerDependenciesMeta:
+      '@glint/template':
+        optional: true
+    dependencies:
+      '@embroider/shared-internals': 2.6.3
+      assert-never: 1.2.1
+      babel-import-util: 2.0.1
+      ember-cli-babel: 7.26.11
+      find-up: 5.0.0
+      lodash: 4.17.21
+      resolve: 1.22.8
+      semver: 7.5.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@embroider/shared-internals/2.0.0:
     resolution: {integrity: sha512-qZ2/xky9mWm5YC6noOa6AiAwgISEQ78YTZNv4SNu2PFgEK/H+Ha/3ddngzGSsnXkVnIHZyxIBzhxETonQYHY9g==}
     engines: {node: 12.* || 14.* || >= 16}
@@ -2117,6 +2150,24 @@ packages:
       typescript-memoize: 1.1.1
     transitivePeerDependencies:
       - supports-color
+
+  /@embroider/shared-internals/2.6.3:
+    resolution: {integrity: sha512-wyFQNSqN+RZWg5ckqsk0Qfun433aEd70L6sc16sY4FFf/AzDnolmc0t3eR7lkdyxltYSrO5eqkFN7hW7l/glaw==}
+    engines: {node: 12.* || 14.* || >= 16}
+    dependencies:
+      babel-import-util: 2.0.1
+      debug: 4.3.4
+      ember-rfc176-data: 0.3.18
+      fs-extra: 9.1.0
+      js-string-escape: 1.0.1
+      lodash: 4.17.21
+      minimatch: 3.1.2
+      resolve-package-path: 4.0.3
+      semver: 7.5.4
+      typescript-memoize: 1.1.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /@embroider/test-setup/2.1.1:
     resolution: {integrity: sha512-t81a2z2OEFAOZVbV7wkgiDuCyZ3ajD7J7J+keaTfNSRiXoQgeFFASEECYq1TCsH8m/R+xHMRiY59apF2FIeFhw==}
@@ -3788,7 +3839,6 @@ packages:
 
   /assert-never/1.2.1:
     resolution: {integrity: sha512-TaTivMB6pYI1kXwrFlEhLeGfOqoDNdTxjCdwRfFFkEA30Eu+k48W34nlok2EYWJfFFzqaEmichdNM7th6M5HNw==}
-    dev: true
 
   /assign-symbols/1.0.0:
     resolution: {integrity: sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==}
@@ -5503,6 +5553,10 @@ packages:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
     engines: {node: '>= 12'}
 
+  /common-ancestor-path/1.0.1:
+    resolution: {integrity: sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==}
+    dev: false
+
   /common-tags/1.8.2:
     resolution: {integrity: sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==}
     engines: {node: '>=4.0.0'}
@@ -6394,6 +6448,16 @@ packages:
       - supports-color
     dev: false
 
+  /ember-browser-services/5.0.0:
+    resolution: {integrity: sha512-HsfshVsZbmqvwEom/Gk1djhbgaw6lu5nFzF5SI+IWBfuXDKGu6IHMKszKbTRuqEI/PiLJtKmU3cRg+MUSCSTxg==}
+    dependencies:
+      '@embroider/addon-shim': 1.8.6
+      ember-window-mock: 1.0.2
+    transitivePeerDependencies:
+      - '@glint/template'
+      - supports-color
+    dev: false
+
   /ember-cli-app-version/5.0.0:
     resolution: {integrity: sha512-afhx/CXDOMNXzoe4NDPy5WUfxWmYYHUzMCiTyvPBxCDBXYcMrtxNWxvgaSaeqcoHVEmqzeyBj8V82tzmT1dcyw==}
     engines: {node: 10.* || >= 12}
@@ -7063,6 +7127,16 @@ packages:
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 6.3.0
     transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /ember-window-mock/1.0.2:
+    resolution: {integrity: sha512-05qmab/YLHwg3Pn+NfQh7PwGY2H1GimxhNKxEoBX6/H3aMGmgwk9rOsV7fFV1PjZrq/V6op+BIqSfObw35psHg==}
+    dependencies:
+      '@embroider/addon-shim': 1.8.9
+      '@embroider/macros': 1.16.6
+    transitivePeerDependencies:
+      - '@glint/template'
       - supports-color
     dev: false
 
@@ -8134,7 +8208,6 @@ packages:
     dependencies:
       locate-path: 6.0.0
       path-exists: 4.0.0
-    dev: true
 
   /find-yarn-workspace-root/1.2.1:
     resolution: {integrity: sha512-dVtfb0WuQG+8Ag2uWkbG79hOUzEsRrhBzgfn86g2sJPkzmcpGdghbNTfUKGTxymFrY/tLIodDzLoW9nOJ4FY8Q==}
@@ -9827,7 +9900,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       p-locate: 5.0.0
-    dev: true
 
   /lodash._baseassign/3.2.0:
     resolution: {integrity: sha512-t3N26QR2IdSN+gqSy9Ds9pBu/J1EAFEshKlUHpJG3rvyJOYgcELIxcIeKKfZk7sjOz11cFfzJRsyFry/JyabJQ==}
@@ -10803,7 +10875,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       yocto-queue: 0.1.0
-    dev: true
 
   /p-locate/2.0.0:
     resolution: {integrity: sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==}
@@ -10830,7 +10901,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       p-limit: 3.1.0
-    dev: true
 
   /p-map/2.1.0:
     resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
@@ -10907,7 +10977,6 @@ packages:
   /path-exists/4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
-    dev: true
 
   /path-is-absolute/1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
@@ -13851,4 +13920,3 @@ packages:
   /yocto-queue/0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
-    dev: true

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@crowdstrike/tailwind-toucan-base": "^5.0.0",
     "@crowdstrike/ember-toucan-styles": "workspace:../ember-toucan-styles",
-    "ember-browser-services": "^4.0.3"
+    "ember-browser-services": "^5.0.0"
   },
   "devDependencies": {
     "@babel/core": "7.20.12",


### PR DESCRIPTION
Widen the version range of the dependency on ember-browser-services to support both v4 and v5.

Also had to update some node and pnpm setup alongside, since installing deps failed locally and on CI.